### PR TITLE
Update Go version to 1.17.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,9 @@ require (
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
 	go.etcd.io/bbolt v1.3.6
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/net v0.0.0-20211013171255-e13a2654a71e
+	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -78,12 +81,6 @@ require (
 require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/klauspost/compress v1.13.6 // indirect
-)
-
-require (
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
-	golang.org/x/net v0.0.0-20211013171255-e13a2654a71e
-	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c
 )
 
 require (


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR makes the Go components of Traffic Control build using Go version 1.17.8 and updates the `golang.org/x/` dependencies..

See the Go 1.17.8 [release notes](https://golang.org/doc/devel/release.html#go1.17):

<!--
The release notes are licensed with the Go license.

Copyright (c) 2009 The Go Authors. All rights reserved.

Redistribution and use in source and binary forms, with or without
modification, are permitted provided that the following conditions are
met:

   * Redistributions of source code must retain the above copyright
notice, this list of conditions and the following disclaimer.
   * Redistributions in binary form must reproduce the above
copyright notice, this list of conditions and the following disclaimer
in the documentation and/or other materials provided with the
distribution.
   * Neither the name of Google Inc. nor the names of its
contributors may be used to endorse or promote products derived from
this software without specific prior written permission.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-->
> <p> go1.17.8 (released 2022-03-03) includes a security fix to the <code>regexp/syntax</code> package, as well as bug fixes to the compiler, runtime, the <code>go</code> command, and the <code>crypto/x509</code> and <code>net</code> packages. See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.17.8+label%3ACherryPickApproved">Go 1.17.8 milestone</a> on our issue tracker for details. </p>

## Which Traffic Control components are affected by this PR?
- CDN in a Box - Enroller
- Grove
- Traffic Control Client (Go)
- Traffic Monitor
- Traffic Ops
- Traffic Ops ORT
- Traffic Stats
- CI tests for Go components

## What is the best way to verify this PR?
Run unit tests and API tests. Since this is only a patch-level version update, [the only changes](https://github.com/golang/go/milestone/247?closed=1) were bugfixes. Breaking changes would be unexpected.

## The following criteria are ALL met by this PR
- [x] Existing tests are sufficient, no additional tests necessary
- [x] The documentation only mentions the major Go version, no documentation updates necessary.
- [x] The changelog already mentions updating to Go 1.17, no additional changelog message necessary.
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
